### PR TITLE
Remove traits from source of randomness

### DIFF
--- a/src/creation.c
+++ b/src/creation.c
@@ -24,8 +24,7 @@ void arrayCreation(int array1, int array2, int array3, int array4, Array *ptr) {
 void arrayRandom(Array *ptr) {
   struct timespec ts;
   timespec_get(&ts, TIME_UTC);
-  ptr->size = (ts.tv_nsec * ptr->count) - ptr->count;
-  srand(ptr->size);
+  srand(ts.tv_nsec);
 }
 
 void arraySort(Array *ptr) {


### PR DESCRIPTION
So, as Low Level Learning explained in his video, adding information to the nanosecond time adds predictability in the final number, which can, or _might_ be used to reverse 'engineer' the original number.

Better off just using it fresh off the oven, it's good enough as it is.

Edit: to clarify, this is not a work-and-ready kind off proposal, in the sense that it'd be better to implement what Low Level Learning suggested in his code review, this is just an initial step, and I'm not familiar enough with C lingo and libraries to implement it myself.

I'm more of a Rust guy, like I've been coding in it for a year now so I'm pretty familiar in it, with the downside that I'm not really familiar with C, make no mistake, I can read it, I can cobble things together in it, but I don't have the muscle memory.